### PR TITLE
Update genome parameter for non-default genomes in triCount.R 

### DIFF
--- a/R/triCount.R
+++ b/R/triCount.R
@@ -15,7 +15,7 @@ triFreq <- function(genome=NULL, count=FALSE){
     genome <- BSgenome.Dmelanogaster.UCSC.dm6
   }
 
-  params <- new("BSParams", X = Dmelanogaster, FUN = trinucleotideFrequency, exclude = c("M", "_"), simplify = TRUE)
+  params <- new("BSParams", X = genome, FUN = trinucleotideFrequency, exclude = c("M", "_"), simplify = TRUE)
   snv_data<-as.data.frame(bsapply(params))
   snv_data$genome<-as.integer(rowSums(snv_data))
   snv_data$genome_adj<-(snv_data$genome*2)


### PR DESCRIPTION
With the current parameter assignment, X always points to Dmelanogaster, even if the genome parameter is provided. 

In the case where genome is not provided, the function will default to Dmelanogaster genome, and things will work fine. In the case where a genome is provided, it will throw an error because the Dmelanogaster genome has not been imported to the workspace. 